### PR TITLE
fixing invalid linear grandient direction to make it work with autopr…

### DIFF
--- a/app/assets/stylesheets/rails_admin/aristo/jquery-ui-1.8.7.custom.scss
+++ b/app/assets/stylesheets/rails_admin/aristo/jquery-ui-1.8.7.custom.scss
@@ -69,7 +69,7 @@
 		background: -webkit-linear-gradient(top, #ededed 0%,#c4c4c4 100%); /* Chrome10+,Safari5.1+ */
 		background: -o-linear-gradient(top, #ededed 0%,#c4c4c4 100%); /* Opera11.10+ */
 		background: -ms-linear-gradient(top, #ededed 0%,#c4c4c4 100%); /* IE10+ */
-		background: linear-gradient(top, #ededed 0%,#c4c4c4 100%); /* W3C */
+		background: linear-gradient(to bottom, #ededed 0%,#c4c4c4 100%); /* W3C */
 }
 .ui-widget-header a { color: #4F4F4F; }
 
@@ -83,7 +83,7 @@
 		background: -webkit-linear-gradient(top, #ededed 0%,#c4c4c4 100%); /* Chrome10+,Safari5.1+ */
 		background: -o-linear-gradient(top, #ededed 0%,#c4c4c4 100%); /* Opera11.10+ */
 		background: -ms-linear-gradient(top, #ededed 0%,#c4c4c4 100%); /* IE10+ */
-		background: linear-gradient(top, #ededed 0%,#c4c4c4 100%); /* W3C */
+		background: linear-gradient(to bottom, #ededed 0%,#c4c4c4 100%); /* W3C */
 	-webkit-box-shadow: 0 1px 0 rgba(255,255,255,0.6) inset;
 	-moz-box-shadow: 0 1px 0 rgba(255,255,255,0.6) inset;
 	box-shadow: 0 1px 0 rgba(255,255,255,0.6) inset;
@@ -100,7 +100,7 @@
 		background: -webkit-linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* Chrome10+,Safari5.1+ */
 		background: -o-linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* Opera11.10+ */
 		background: -ms-linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* IE10+ */
-		background: linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* W3C */
+		background: linear-gradient(to bottom, #b9e0f5 0%,#92bdd6 100%); /* W3C */
 	-webkit-box-shadow: none;
 	-moz-box-shadow: none;
 	box-shadow: none;
@@ -481,7 +481,7 @@ button.ui-button-icons-only { width: 3.7em; }
 		background: -webkit-linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* Chrome10+,Safari5.1+ */
 		background: -o-linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* Opera11.10+ */
 		background: -ms-linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* IE10+ */
-		background: linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* W3C */
+		background: linear-gradient(to bottom, #b9e0f5 0%,#92bdd6 100%); /* W3C */
 	-moz-box-shadow: 0 0 8px rgba(0, 0, 0, 0.15), 0 1px 0 rgba(255,255,255,0.8) inset; 
 	-webkit-box-shadow: 0 0 8px rgba(0, 0, 0, 0.15), 0 1px 0 rgba(255,255,255,0.8) inset;
 	box-shadow: 0 0 8px rgba(0, 0, 0, 0.15), 0 1px 0 rgba(255,255,255,0.8) inset;
@@ -527,7 +527,7 @@ input.ui-button::-moz-focus-inner {
 		background: -webkit-linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* Chrome10+,Safari5.1+ */
 		background: -o-linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* Opera11.10+ */
 		background: -ms-linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* IE10+ */
-		background: linear-gradient(top, #b9e0f5 0%,#92bdd6 100%); /* W3C */
+		background: linear-gradient(to bottom, #b9e0f5 0%,#92bdd6 100%); /* W3C */
 	-webkit-box-shadow: none;
 	-moz-box-shadow: none;
 	box-shadow: none;


### PR DESCRIPTION
# Description

This PR fixes an issue when using `sassc-rails` + `autoprefixer-rails`. `top` is no longer a valid direction for `linear-gradient`, this makes `autoprefixer` fail to parse the file. `top` has been replaced with `to bottom`. [MDN](https://developer.mozilla.org/es/docs/Web/CSS/linear-gradient#Cross-browser_gradients)
## Media

<img width="1280" alt="screen shot 2015-07-14 at 2 53 58 pm" src="https://cloud.githubusercontent.com/assets/849872/8683390/1e3154fe-2a38-11e5-905d-cd2e6ad4dc23.png">
